### PR TITLE
Fix: wrong variable setted to NULL

### DIFF
--- a/functions.inc/geters_seters.php
+++ b/functions.inc/geters_seters.php
@@ -164,7 +164,7 @@ function queues_add(
 			$callconfirm_id = NULL;
 		}
 	} else {
-		$joinannounce_id = NULL;
+		$callconfirm_id = NULL;
 	}
 	$maxwait		= isset($maxwait) ? $maxwait:'';
 	$password		= isset($password) ? $password:'';


### PR DESCRIPTION
if $callconfirm_id isn't setted, $joinannounce_id is setted to NULL instead of $callconfirm_id
nethesis/dev#5997